### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "BSD-2-Clause",
     "require": {
         "php": ">=5.3.7",
-        "illuminate/support": "4.1.*",
+        "illuminate/support": "4.*",
         "nesbot/carbon": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Added support for Laravel 4.2, since the update failed because of the illuminate/support: "4.1.\* dependency.
