### PR TITLE
BugFix for multiple shorten request new params overide old params

### DIFF
--- a/src/Jelovac/Bitly4laravel/API.php
+++ b/src/Jelovac/Bitly4laravel/API.php
@@ -18,7 +18,7 @@ class API extends Model {
         $this->requestParams['format'] = $this->responseFormat;
 
         if (!empty($params)) {
-            $this->requestParams = array_merge($params, $this->requestParams);
+            $this->requestParams = array_merge($this->requestParams , $params);
         }
 
         if ($this->cacheEnabled) {


### PR DESCRIPTION
In case if shorten is used for many times , in "$this->requestParams" stays old "longUrl" , so it gives out previous short link. In this case , replaced merge sequence , so new parametrs override old parametrs , and new "longUrl" is given in request